### PR TITLE
TASK: Support Bulma >= 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Slider Component for Vue Bulma",
   "main": "src/Slider.vue",
   "peerDependencies": {
-    "bulma": ">=0.2",
+    "bulma": ">=0.4.1",
     "vue": ">=2"
   },
   "repository": "vue-bulma/slider",

--- a/src/Slider.vue
+++ b/src/Slider.vue
@@ -94,7 +94,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~bulma/sass/utilities/variables';
+@import '~bulma/sass/utilities/initial-variables';
+@import '~bulma/sass/utilities/functions';
+@import '~bulma/sass/utilities/derived-variables';
 
 input[type=range].slider {
   $radius: 290486px;


### PR DESCRIPTION
The SASS file structure changed in Bulma 0.4.1, this version works with the new releases. Tested with up to version 0.7.3.

@Mentainer:
Please merge the commit and create a new release.

@Everybody:
You can already use this fix with:
```
yarn upgrade vue-bulma-slider@https://github.com/rolandschuetz/slider.git
```